### PR TITLE
Clean up DATABASE_URL in .env.test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -13,6 +13,3 @@ APP_URL="http://localhost:3000" # Base URL for supertest
 # For testing, it's best to use a *separate* database (e.g., success_academy_test).
 # You might need to manually create this database: CREATE DATABASE success_academy_test;
 # Or, if your schema.sql handles "IF NOT EXISTS", running it against a new DB name is fine.
-# For now, I will use the same database as dev and rely on cleanup.
-# Reverting to the project's default dev database for now, assuming robust cleanup.
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/success_academy"


### PR DESCRIPTION
## Summary
- remove duplicate DATABASE_URL entry from `.env.test`
- keep comments consistent with dedicated test database connection

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c3ad06b0832586071a4c43ea957f