### PR TITLE
Fix stray import in test

### DIFF
--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -1,7 +1,6 @@
 // tests/api/auth.test.ts
 import request from 'supertest';
 import { cleanupUserByEmail, findInstructorByEmail, findSessionByToken, getTestPool, closeTestPool } from '../db-utils'; // Adjust path as needed
-import { Pool }e;
 
 // Load APP_URL from environment, ensure it's set (via tests/setup.ts and .env.test)
 const APP_URL = process.env.APP_URL;


### PR DESCRIPTION
## Summary
- drop unused `Pool` import in `tests/api/auth.test.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'next/server' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6857c453819483259f79c06b70ed32a0