### PR TITLE
Fix signup validation

### DIFF
--- a/app/app/api/auth/signup/route.ts
+++ b/app/app/api/auth/signup/route.ts
@@ -7,6 +7,17 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 export async function POST(req: NextRequest) {
   const { name, email, password } = await req.json();
+
+  if (!name || name.trim() === "") {
+    return NextResponse.json({ error: "Missing name" }, { status: 400 });
+  }
+  if (!email || email.trim() === "") {
+    return NextResponse.json({ error: "Missing email" }, { status: 400 });
+  }
+  if (!password || password.trim() === "") {
+    return NextResponse.json({ error: "Missing password" }, { status: 400 });
+  }
+
   const hash = await bcrypt.hash(password, 10);
 
   try {


### PR DESCRIPTION
## Summary
- ensure `name`, `email`, and `password` are present before hashing

## Testing
- `npm test --silent` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6857d4f78e208325abef846f3f8613f3