### PR TITLE
Add student catalog fetching and purchase page

### DIFF
--- a/app/app/student/catalog/page.tsx
+++ b/app/app/student/catalog/page.tsx
@@ -1,10 +1,62 @@
 // app/app/student/catalog/page.tsx
 "use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+interface Course {
+  id: number;
+  title: string;
+  price: number;
+}
+
 export default function CourseCatalog() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCatalog = async () => {
+      try {
+        const res = await fetch("/api/student/catalog");
+        const data = await res.json();
+        setCourses(data.courses);
+      } catch (err) {
+        console.error("Failed to load catalog", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCatalog();
+  }, []);
+
   return (
     <div className="p-6 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Course Catalog</h1>
-      {/* Course cards go here */}
+      {loading ? (
+        <p>Loading courses...</p>
+      ) : courses.length === 0 ? (
+        <p>No courses available.</p>
+      ) : (
+        <div className="space-y-4">
+          {courses.map((course) => (
+            <div
+              key={course.id}
+              className="p-4 bg-white rounded shadow flex items-center justify-between"
+            >
+              <div>
+                <h2 className="text-xl font-semibold">{course.title}</h2>
+                <p className="text-gray-600">${course.price.toFixed(2)}</p>
+              </div>
+              <Link
+                href={`/student/purchase?courseId=${course.id}`}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+              >
+                Purchase
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/app/student/purchase/page.tsx
+++ b/app/app/student/purchase/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+export default function PurchasePage() {
+  const searchParams = useSearchParams();
+  const courseId = Number(searchParams.get("courseId"));
+
+  const [studentId, setStudentId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/student/purchase", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          studentId: Number(studentId),
+          courseId,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Purchase failed");
+      } else {
+        setSuccess(true);
+      }
+    } catch (err) {
+      setError("Purchase failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="p-6 text-center">
+        <h1 className="text-2xl font-bold mb-4">Purchase Complete</h1>
+        <p>Thank you for your purchase.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded shadow w-full max-w-md"
+      >
+        <h1 className="text-xl font-bold mb-4">Purchase Course</h1>
+        {error && <p className="mb-4 text-red-600">{error}</p>}
+        <input type="hidden" value={courseId} />
+        <label className="block mb-4 text-gray-700">
+          Student ID
+          <input
+            type="number"
+            required
+            value={studentId}
+            onChange={(e) => setStudentId(e.target.value)}
+            className="w-full mt-1 p-2 border rounded text-gray-900"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
+        >
+          {loading ? "Processing..." : "Purchase"}
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement catalog page fetching `/api/student/catalog`
- list courses with purchase links
- add a simple purchase page that posts to `/api/student/purchase`

## Testing
- `npm test` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68583bee1ba483258c1956cbb509eb1d