### PR TITLE
Fix standalone build start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=builder /app/next.config.* ./
 COPY --from=builder /app/postcss.config.* ./
 COPY --from=builder /app/tailwind.config.* ./
 
-# Start the app
-CMD ["npm", "start"]
+# Start the app using the standalone server
+CMD ["node", ".next/standalone/server.js"]


### PR DESCRIPTION
## Summary
- start the container with `node .next/standalone/server.js` instead of `next start`

## Testing
- `npm test` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68588935daf483258bab1d965b98a7ad