### PR TITLE
Enable Node middleware in Next config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,5 @@ COPY --from=builder /app/next.config.* ./
 COPY --from=builder /app/postcss.config.* ./
 COPY --from=builder /app/tailwind.config.* ./
 
-# Start the app
-CMD ["npm", "start"]
+# Start the app using the standalone server
+CMD ["node", ".next/standalone/server.js"]

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,10 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  experimental: {
-    appDir: true,
-    nodeMiddleware: true,
-  },
 };
 
 export default nextConfig;

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    appDir: true,
+    nodeMiddleware: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- enable `appDir` and `nodeMiddleware` options in `app/next.config.ts`

## Testing
- `npm test` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_68588935daf483258bab1d965b98a7ad