### PR TITLE
Fix Tailwind import and add pg dev dependency

### DIFF
--- a/app/app/globals.css
+++ b/app/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "jest-environment-node": "^30.0.0-beta.3",
     "supertest": "^7.1.1",
     "ts-jest": "^29.3.4",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "pg": "^8.11.3"
   },
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
## Summary
- fix Tailwind initialization by using `@tailwind` directives
- add `pg` to dev dependencies so Jest tests can load the pg module

## Testing
- `npm test` *(fails: Cannot find module 'pg')*
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6858df6d47688325b7edc2cabaab5d5f